### PR TITLE
This fix helps running this plugin on Windows.

### DIFF
--- a/lib/embulk/input_pcapng_files.rb
+++ b/lib/embulk/input_pcapng_files.rb
@@ -71,7 +71,7 @@ module Embulk
     def build_options(fields)
       options = ""
       fields.each do |field|
-        options += "-e '#{field}' "
+        options += "-e \"#{field}\" "
       end
       return options
     end


### PR DESCRIPTION
The same failure can be seen by running tshark with the following options.

$ tshark -E separator=, -e "'frame.number'" -e "'wlan.ta'" -e "'wlan.ra'" -T fields -r xxx.pcapng

*\* (tshark.exe:7912): WARNING **: ''frame.number'' isn't a valid field!

*\* (tshark.exe:7912): WARNING **: ''wlan.ta'' isn't a valid field!

*\* (tshark.exe:7912): WARNING **: ''wlan.ra'' isn't a valid field!
tshark: Some fields aren't valid
